### PR TITLE
Feature: Add Convert Email List functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,43 @@
-# InterviewListConverter
-MS Teams our Outlook Invites to a list
+# Interview List Converter
 
-https://app.netlify.com/sites/interviewlist/overview
+A web application to parse and format lists of names from Outlook invites, MS Teams attendance lists, and to filter participants from TSV data based on their response status. All processing is done client-side in your browser.
 
+## Input Methods
 
-https://interviewlist.netlify.app/
+### Outlook Invites
 
-test git update
+*   **Instructions:** Go to the Outlook invite -> Terminplanungs-Assistent / Scheduling Assistant -> Mark all attendees -> Copy (Ctrl+C) -> Paste into the 'Outlook Invites' input field.
+*   **Expected Format:** Names separated by semicolons (`;`). Expected format is 'Last name, First name'.
+
+### MS Teams Attendance List
+
+*   **Instructions:** In MS Teams: People -> Participants -> Three Dots (...) -> Download Attendance List. Then either:
+    *   **Option A (Text Area):** Open the downloaded CSV file (usually tab-separated), copy the column containing names, and paste it into the 'MS Teams Attendance List' text area. One name per line. Expected format is 'Last name, First name'.
+    *   **Option B (CSV Upload):** Click 'Upload CSV' and select the downloaded attendance file. The tool expects names to be in the first column and the file to be tab-separated.
+
+### Nachverfolgung (Tracking/Filtering)
+
+*   **Instructions:** Paste Tab-Separated Values (TSV) data from your tracking sheet (e.g., from Excel) into the 'Nachverfolgung' text area. The tool expects the first column to be the participant's name and the third column to be their response status.
+*   **Functionality:** Use the filter buttons ('Filter Zugesagt', 'Filter Mit Vorbehalt', 'Filter Abgelehnt', 'Filter Keine', 'Filter All') to display names based on their response. 'Filter All' displays all names from the pasted TSV data.
+
+### Convert Email List
+
+This feature allows you to paste a list of email recipients, typically copied from an email client's To: or CC: fields. The tool will attempt to extract individual names and format them as 'FirstName LastName'.
+
+You can paste a list of entries separated by commas (`,`), semicolons (`;`), or newlines. The tool can parse formats such as:
+*   `FirstName LastName <email@example.com>`
+*   `"LastName, FirstName" <email@example.com>`
+*   `email@example.com`
+*   `FirstName.LastName@example.com`
+
+If a name is explicitly provided with the email, it will be used (and flipped if in 'Last, First' format). If only an email address is provided, the tool will attempt to create a name from the local part of the email (e.g., 'john.doe' from 'john.doe@example.com' becomes 'John Doe').
+
+## Output
+
+The application will display a cleaned, formatted, and (if applicable) filtered list of names. You can then:
+*   Copy individual names by checking the box next to their name and clicking "Copy Selected".
+*   Copy all names in the displayed list by clicking "Copy All".
+
+## Privacy
+
+Everything happens in your browser. No names or files are ever uploaded to any server.

--- a/index.html
+++ b/index.html
@@ -49,8 +49,16 @@
                     <button id="filterVorbehaltBtn">Filter Mit Vorbehalt</button>
                     <button id="filterDeclineBtn">Filter Abgelehnt</button>
                     <button id="filterNoResponseBtn">Filter Keine</button>
-                    <button id="filterAllBtn">Filter All(Wip)</button>
+                    <button id="filterAllBtn">Filter All</button>
             </div>
+        </div>
+        <div class="section">
+                <h3 onclick="toggleSection('content-email-list')">Convert Email List <i class="fas fa-chevron-down" id="icon-email-list"></i></h3>
+                <div id="content-email-list" class="content">
+                    <p>Paste a list of emails (e.g., from Outlook's To/CC fields). The tool will attempt to extract and format names as 'Firstname Lastname'.</p>
+                    <textarea id="emailListInput" rows="4" cols="50" placeholder="Paste email list here..."></textarea>
+                    <button id="convertEmailListBtn">Convert</button>
+                </div>
         </div>
         <h3>Interview List</h3>
         <ul id="resultList"></ul>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
                 <h3 onclick="toggleSection('content-outlook')">Outlook Invites <i class="fas fa-chevron-down" id="icon-outlookInvites"></i></h3>
                 <div id="content-outlook" class="content show">
                     <p>Go to invite -> Terminplanungs-Assistent / Scheduling assistant -> Mark all + copy -> insert here</p>
-                    <input type="text" id="inputString" placeholder="Enter names separated by ';' Format last name, first name expected">
+                    <input type="text" id="inputString" placeholder="Enter names separated by ';' Format: Lastname, Firstname e.g., Mustermann, Max; Doe, John">
                     <button id="convertInputBtn">Convert</button>
                 </div>
         </div>
@@ -31,7 +31,7 @@
                 <h3 onclick="toggleSection('content-attendance-list')">MS Teams Attendance List<i class="fas fa-chevron-down" id="icon-ms-teams-attendance-list"></i></h3>
                 <div id="content-attendance-list" class="content">
                     <p>People -> Participants -> Three Dots "..."" -> Download Attendance List -> first row in csv after opening in Excel</p>
-                    <textarea id="inputTextarea" rows="4" cols="50" placeholder="Enter names, one per line; Format last name, first name expected"></textarea>
+                    <textarea id="inputTextarea" rows="4" cols="50" placeholder="Enter names, one per line; Format: Lastname, Firstname e.g., Mustermann, Max\nDoe, John"></textarea>
                     <button id="convertTextareaBtn">Convert</button>
                     <label class="file-upload">
                         Upload CSV
@@ -44,7 +44,7 @@
                 <h3 onclick="toggleSection('content-zugesagtFilter')">Nachverfolgung<i class="fas fa-chevron-down" id="icon-zugesagtFilter"></i></h3>
                 <div id="content-zugesagtFilter" class="content">
                     <p>Paste your TSV data here to filter names with the response corresponding response</p>
-                    <textarea id="inputZugesagtData" rows="6" cols="50" placeholder="Paste TSV data here"></textarea>
+                    <textarea id="inputZugesagtData" rows="6" cols="50" placeholder="Paste TSV data here\ne.g., Mustermann, Max\tSomeOtherData\tZugesagt\nDoe, John\tSomeOtherData\tAbgesagt"></textarea>
                     <button id="filterZugesagtBtn">Filter Zugesagt</button>
                     <button id="filterVorbehaltBtn">Filter Mit Vorbehalt</button>
                     <button id="filterDeclineBtn">Filter Abgelehnt</button>
@@ -56,7 +56,7 @@
                 <h3 onclick="toggleSection('content-email-list')">Convert Email List <i class="fas fa-chevron-down" id="icon-email-list"></i></h3>
                 <div id="content-email-list" class="content">
                     <p>Paste a list of emails (e.g., from Outlook's To/CC fields). The tool will attempt to extract and format names as 'Firstname Lastname'.</p>
-                    <textarea id="emailListInput" rows="4" cols="50" placeholder="Paste email list here..."></textarea>
+                    <textarea id="emailListInput" rows="4" cols="50" placeholder="Paste email list here...\ne.g., Max Mustermann <max.mustermann@example.com>; doe.john@example.com; &quot;Doe, Jane&quot; <jane.doe@example.com>"></textarea>
                     <button id="convertEmailListBtn">Convert</button>
                 </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -10,9 +10,10 @@ function copyToClipboard(text) {
     });
 }
 
-function showCopyNotification() {
-    console.log('showCopyNotification called'); // This should appear in your browser console when the function is called
+function showCopyNotification(message) {
+    console.log('showCopyNotification called with message:', message);
     const notification = document.getElementById('copyNotification');
+    notification.textContent = message; // Set the message
     notification.style.display = 'block';
     notification.style.opacity = '1';
     notification.style.visibility = 'visible';
@@ -62,7 +63,6 @@ function copySelected() {
     const textToCopy = namesToCopy.join("\n");
     if (textToCopy) {
         copyToClipboard(textToCopy);
-        showCopyNotification(); // Show notification
     } else {
         showCopyNotification("No names selected!"); // Show error message if nothing selected
     }
@@ -76,20 +76,11 @@ function copyAll() {
 
     if (namesToCopy.length > 0) {
         copyToClipboard(namesToCopy.join("\n"));
-        showCopyNotification(); // Show notification
     } else {
         showCopyNotification("No names to copy!"); // Optionally show a message if there's nothing to copy
     }
 }
 
-function copyToClipboard(text) {
-    const textarea = document.createElement("textarea");
-    textarea.textContent = text;
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand("copy");
-    document.body.removeChild(textarea);
-}
 
 function convertTextareaToList() {
     const input = document.getElementById("inputTextarea").value.trim();
@@ -112,21 +103,41 @@ function handleFile() {
 }
 
 function parseCSVtoTextarea(data) {
+    const textarea = document.getElementById('inputTextarea'); // Get textarea element first
     const rows = data.split('\n');
     let names = [];
 
-    // Starting from index 1 to skip the header row
+    // Check if rows is empty or only contains a header.
+    // Filter out empty strings from rows before checking length for more robustness.
+    const contentRows = rows.filter(row => row.trim() !== '');
+    if (contentRows.length <= 1) {
+        alert("CSV file is empty or contains only a header.");
+        textarea.value = ""; // Clear the textarea
+        return;
+    }
+
+    // Starting from index 1 of the original rows array to skip the header row
     for (let i = 1; i < rows.length; i++) {
+        // Check if rows[i] is empty, null, or undefined, or just whitespace
+        if (!rows[i] || rows[i].trim() === '') {
+            continue;
+        }
         const cells = rows[i].split('\t');
 
-        // Assuming names are in the first column
-        if (cells[0]) {
+        // Assuming names are in the first column and it's not empty/whitespace
+        if (cells[0] && cells[0].trim() !== '') {
             names.push(cells[0].trim());
         }
     }
 
-    const textarea = document.getElementById('inputTextarea');
-    textarea.value = names.join('\n');
+    if (names.length === 0) {
+        // This can happen if the first column is empty for all data rows, or if the delimiter isn't a tab.
+        alert("No names found in the selected CSV file. Please ensure the file is tab-separated and names are in the first column.");
+        textarea.value = ""; // Clear textarea if no names found
+    } else {
+        alert(`CSV parsed successfully, ${names.length} names loaded.`);
+        textarea.value = names.join('\n');
+    }
 }
 
 function displayNames(names) {
@@ -136,8 +147,8 @@ function displayNames(names) {
     // Remove duplicates and empty names, then sort by email domain
     names = [...new Set(names.filter(name => name.trim() !== ''))]
         .sort((a, b) => {
-            const domainA = a.split('@')[1] || '';
-            const domainB = b.split('@')[1] || '';
+            const domainA = a.split('@')[1] || ''; // Handle cases where name might not have @
+            const domainB = b.split('@')[1] || ''; // Handle cases where name might not have @
             return domainA.localeCompare(domainB);
         });
 
@@ -153,22 +164,33 @@ function displayNames(names) {
 
         // Extract email domain (if present)
         const emailParts = name.split('@');
-        const domain = emailParts.length > 1 ? '@' + emailParts[1] : '';
+        let displayName = name;
+        let domain = '';
 
+        if (emailParts.length > 1) {
+            displayName = emailParts[0];
+            domain = '@' + emailParts[1];
+        }
+        
         // Remove any email address and dots from the name
-        name = emailParts[0].replace(/\./g, ' ');
+        displayName = displayName.replace(/\./g, ' ');
 
         // Flip last and first names if there's a comma
-        if (name.includes(",")) {
-            let [lastName, firstName] = name.split(",").map(n => n.trim());
-            name = `${firstName} ${lastName}`;
+        if (displayName.includes(",")) {
+            let [lastName, firstName] = displayName.split(",").map(n => n.trim());
+            if (firstName && lastName) { // Ensure both parts exist
+                displayName = `${firstName} ${lastName}`;
+            } else if (lastName) { // Only lastName exists (e.g. "Doe,")
+                displayName = lastName;
+            } // if only firstName, it's already correct
         }
 
         // Store the name without domain in the dataset for copying
-        label.dataset.name = name.trim();
+        label.dataset.name = capitalize(displayName.trim()); // Capitalize before storing
 
         // Display name with domain in UI
-        label.innerHTML = `${name.trim()} <span class="domain">${domain}</span>`;
+        label.innerHTML = `${capitalize(displayName.trim())} <span class="domain">${domain}</span>`;
+
 
         li.appendChild(checkbox);
         li.appendChild(label);
@@ -204,115 +226,128 @@ function toggleCopyAll() {
     }
 }
 
-function filterAndDisplayZugesagt(data) {
+// Generic filter function
+function filterAndDisplayGeneric(data, columnIndex, expectedValue, matchAll = false) {
     const rows = data.split('\n');
-    let namesZugesagt = [];
+    const filteredNames = []; // Use a generic name
 
     // Starting from index 1 to skip the header row
     for (let i = 1; i < rows.length; i++) {
+        if (!rows[i] || rows[i].trim() === '') { // Skip empty or whitespace-only rows
+            continue;
+        }
         const cells = rows[i].split('\t');
 
-        // Check if the response is 'Zugesagt' and add to the list
-        if (cells[2] && cells[2].trim() === 'Zugesagt') {
+        // Ensure cells[0] (for name) exists. If not, we can't process this row for a name.
+        if (!cells[0] || cells[0].trim() === '') { 
+            continue;
+        }
+        
+        // If not matching all, ensure the cell for the condition exists.
+        if (!matchAll && (typeof cells[columnIndex] === 'undefined')) { 
+            continue;
+        }
+
+        if (matchAll || (cells[columnIndex] && cells[columnIndex].trim() === expectedValue)) {
             let name = cells[0].trim();
             if (name.includes(",")) {
                 const splitName = name.split(",").map(n => n.trim());
-                name = splitName[1] + " " + splitName[0]; // Flipping the name
+                // Ensure both parts exist after split before trying to access them
+                if (splitName.length >= 2 && splitName[0] && splitName[1]) {
+                    name = splitName[1] + " " + splitName[0]; // Flipping the name
+                } 
             }
-            namesZugesagt.push(name);
+            if (name) { 
+                 filteredNames.push(name);
+            }
         }
     }
+    displayNames(filteredNames);
+}
 
-    displayNames(namesZugesagt);
+// Refactored specific filter functions
+function filterAndDisplayZugesagt(data) {
+    filterAndDisplayGeneric(data, 2, 'Zugesagt');
 }
 
 function filterAndDisplayVorbehalt(data) {
-    const rows = data.split('\n');
-    let namesZugesagt = [];
-
-    // Starting from index 1 to skip the header row
-    for (let i = 1; i < rows.length; i++) {
-        const cells = rows[i].split('\t');
-
-        // Check if the response is 'Zugesagt' and add to the list
-        if (cells[2] && cells[2].trim() === 'Mit Vorbehalt') {
-            let name = cells[0].trim();
-            if (name.includes(",")) {
-                const splitName = name.split(",").map(n => n.trim());
-                name = splitName[1] + " " + splitName[0]; // Flipping the name
-            }
-            namesZugesagt.push(name);
-        }
-    }
-
-    displayNames(namesZugesagt);
+    filterAndDisplayGeneric(data, 2, 'Mit Vorbehalt');
 }
 
 function filterAndDisplayDecline(data) {
-    const rows = data.split('\n');
-    let namesZugesagt = [];
-
-    // Starting from index 1 to skip the header row
-    for (let i = 1; i < rows.length; i++) {
-        const cells = rows[i].split('\t');
-
-        // Check if the response is 'Abgesagt' and add to the list
-        if (cells[2] && cells[2].trim() === 'Abgesagt') {
-            let name = cells[0].trim();
-            if (name.includes(",")) {
-                const splitName = name.split(",").map(n => n.trim());
-                name = splitName[1] + " " + splitName[0]; // Flipping the name
-            }
-            namesZugesagt.push(name);
-        }
-    }
-
-    displayNames(namesZugesagt);
+    filterAndDisplayGeneric(data, 2, 'Abgesagt');
 }
 
 function filterAndDisplayNoResponse(data) {
-    const rows = data.split('\n');
-    let namesZugesagt = [];
-
-    // Starting from index 1 to skip the header row
-    for (let i = 1; i < rows.length; i++) {
-        const cells = rows[i].split('\t');
-
-        // Check if the response is 'Abgesagt' and add to the list
-        if (cells[2] && cells[2].trim() === 'Keine') {
-            let name = cells[0].trim();
-            if (name.includes(",")) {
-                const splitName = name.split(",").map(n => n.trim());
-                name = splitName[1] + " " + splitName[0]; // Flipping the name
-            }
-            namesZugesagt.push(name);
-        }
-    }
-
-    displayNames(namesZugesagt);
+    filterAndDisplayGeneric(data, 2, 'Keine');
 }
 
 function filterAndDisplayAll(data) {
-    const rows = data.split('\n');
-    let namesZugesagt = [];
+    filterAndDisplayGeneric(data, 0, '', true);
+}
 
-    // Starting from index 1 to skip the header row
-    for (let i = 1; i < rows.length; i++) {
-        const cells = rows[i].split('\t');
-
-        // Check if the response is 'Abgesagt' and add to the list
-        if (true) {
-            let name = cells[0].trim();
-            if (name.includes(",")) {
-                const splitName = name.split(",").map(n => n.trim());
-                name = splitName[1] + " " + splitName[0]; // Flipping the name
-            }
-            namesZugesagt.push(name);
-        }
+function convertEmailList() {
+    const input = document.getElementById('emailListInput').value.trim();
+    if (!input) {
+        alert("Email list input is empty.");
+        displayNames([]); // Clear the list if input is empty
+        return;
     }
 
-    displayNames(namesZugesagt);
+    const extractedNames = new Set(); // Use Set to avoid duplicates initially
+    const entries = input.split(/[,;\n]+/); 
+
+    const emailRegex = /(?:"?\s*([^"<>,;]+?)\s*"?\s*)?<([^@]+@[^>]+)>/;
+    // Simpler regex for just email:
+    const plainEmailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+
+    for (let entry of entries) {
+        entry = entry.trim();
+        if (!entry) {
+            continue;
+        }
+
+        let nameToProcess = null;
+        const match = entry.match(emailRegex);
+
+        if (match) { // Format: "Name" <email> or <email>
+            if (match[1]) { // Name part exists
+                nameToProcess = match[1].trim();
+                if (nameToProcess.includes(',')) {
+                    const parts = nameToProcess.split(',').map(p => p.trim());
+                    if (parts.length >= 2 && parts[0] && parts[1]) {
+                        nameToProcess = `${parts[1]} ${parts[0]}`;
+                    }
+                }
+            } else if (match[2]) { // No name part, but email in brackets exists
+                let emailUser = match[2].split('@')[0];
+                nameToProcess = emailUser.replace(/[._]/g, ' ');
+            }
+        } else if (entry.includes('@') && plainEmailRegex.test(entry)) { // Likely just an email address
+            let emailUser = entry.split('@')[0];
+            nameToProcess = emailUser.replace(/[._]/g, ' ');
+        } else if (!entry.includes('<') && !entry.includes('>') && !entry.includes('@')) { // No <, >, @ treat as a potential name
+            nameToProcess = entry;
+            if (nameToProcess.includes(',')) {
+                const parts = nameToProcess.split(',').map(p => p.trim());
+                if (parts.length >= 2 && parts[0] && parts[1]) {
+                    nameToProcess = `${parts[1]} ${parts[0]}`;
+                }
+            }
+        }
+        // Else: unparseable entry, skip.
+
+        if (nameToProcess) {
+            const capitalizedName = capitalize(nameToProcess);
+            if (capitalizedName.trim() !== "") {
+                 extractedNames.add(capitalizedName); // Add to Set
+            }
+        }
+    }
+    displayNames(Array.from(extractedNames)); // Convert Set to Array for displayNames
 }
+
 
 function toggleSection(sectionId) {
     var section = document.getElementById(sectionId);
@@ -329,9 +364,10 @@ function toggleSection(sectionId) {
 
 function capitalize(str) {
     // Split the string into words if there's a space or dot followed by a character
-    return str.split(/(?<=\.)\s*|\s+/).map(word => 
-        word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-    ).join(' ');
+    return str.split(/(?<=\.)\s*|\s+|(?<=\_)\s*/).map(word => {
+        if (word.length === 0) return '';
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    }).join(' ').replace(/\s+/g, ' ').trim(); // Normalize spaces and trim
 }
 
 
@@ -350,6 +386,10 @@ document.addEventListener("DOMContentLoaded", function() {
     // Event listener for file upload
     document.getElementById("csvFile").addEventListener("change", handleFile);
 
+    // Event listener for the new email list converter button
+    document.getElementById("convertEmailListBtn").addEventListener("click", convertEmailList);
+
+
     // Add event listeners for each icon
     document.getElementById("icon-outlookInvites").addEventListener("click", function() {
         toggleSection('content-outlook');
@@ -361,12 +401,17 @@ document.addEventListener("DOMContentLoaded", function() {
     document.getElementById("icon-zugesagtFilter").addEventListener("click", function() {
         toggleSection('content-zugesagtFilter');
     });
+    // Event listener for the new email list section icon
+    document.getElementById("icon-email-list").addEventListener("click", function() {
+        toggleSection('content-email-list');
+    });
+
     document.getElementById("filterZugesagtBtn").addEventListener("click", function() {
-        const inputData = document.getElementById("inputZugesagtData").value; // Corrected ID
+        const inputData = document.getElementById("inputZugesagtData").value; 
         filterAndDisplayZugesagt(inputData);
     });
     document.getElementById("filterVorbehaltBtn").addEventListener("click", function() {
-        const inputData = document.getElementById("inputZugesagtData").value; // Corrected ID
+        const inputData = document.getElementById("inputZugesagtData").value; 
         filterAndDisplayVorbehalt(inputData);
     });
     document.getElementById("filterDeclineBtn").addEventListener("click", function() {
@@ -382,4 +427,3 @@ document.addEventListener("DOMContentLoaded", function() {
         filterAndDisplayAll(inputData);
     }); 
 });
-


### PR DESCRIPTION
This commit introduces a new feature allowing you to paste a list of email addresses (e.g., from Outlook's To/CC fields) and convert them into a formatted list of names.

Key changes:

- **index.html:**
    - Added a new collapsible section titled "Convert Email List".
    - Includes a textarea (`emailListInput`) for pasting email strings.
    - Added a "Convert" button (`convertEmailListBtn`) to trigger the parsing.

- **script.js:**
    - Implemented `convertEmailList()` function: - Parses input strings separated by commas, semicolons, or newlines. - Extracts names from formats like "FirstName LastName <email@example.com>", "LastName, FirstName <email@example.com>", and plain email addresses. - Derives names from email local parts (e.g., `first.last@domain.com` -> "First Last") if explicit names are not provided. - Handles comma flipping for "Last, First" name formats. - Uses a Set to ensure unique names are displayed.
    - Refined `capitalize()` function:
        - Improved to handle names separated by dots (`.`), spaces (` `), or underscores (`_`).
        - Normalizes multiple spaces and trims results.
    - Added event listeners for the new button and section toggle icon.
    - Updated `displayNames` to ensure `label.dataset.name` uses the capitalized and trimmed name.

- **README.md:**
    - Added documentation for the "Convert Email List" feature, explaining its usage, supported input formats, and name extraction logic.

This feature enhances the utility of the tool by providing another convenient way to process and format lists of people.

Output: