### PR TITLE
Configure project for Netlify deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build:css"
+  publish = "."

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.20",
-    "tailwindcss": "^3.3.0"
+    "tailwindcss": "^3.3.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",
@@ -32,7 +33,6 @@
     "@radix-ui/react-slot": "^1.2.3",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",
-    "tailwind-merge": "^3.3.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwind-merge": "^3.3.0"
   }
 }


### PR DESCRIPTION
Adds `netlify.toml` to specify the build command and publish directory. Ensures that all build-related dependencies (tailwindcss, postcss, autoprefixer, tailwindcss-animate) are correctly listed in devDependencies in `package.json`.

The site will be built using `npm run build:css` and published from the root directory. No changes to file paths were necessary. This should resolve issues with styling not appearing on Netlify by ensuring the Tailwind CSS build process is executed during deployment.