### PR TITLE
Feat: Implement Dark Mode Toggle and Add Header Emoji


    - 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark"> <!-- Assuming dark mode by default, can be toggled by JS -->
+<html lang="en"> <!-- JS will handle dark class -->
 
 <head>
     <meta charset="UTF-8">
@@ -13,7 +13,14 @@
     <div class="container mx-auto p-4 md:p-8 max-w-3xl">
         
         <header class="mb-8 text-center">
-            <h1 class="text-4xl font-bold tracking-tight text-primary mb-2">Interview List Converter</h1>
+            <div class="flex justify-center items-center relative"> <!-- Added a wrapper for positioning -->
+                <h1 class="text-4xl font-bold tracking-tight text-primary mb-2">📝 Interview List Converter</h1>
+                <button id="darkModeToggle" type="button" class="absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-inset focus:ring-ring">
+                    <svg id="theme-toggle-dark-icon" class="hidden h-5 w-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
+                    <svg id="theme-toggle-light-icon" class="hidden h-5 w-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm.001 6.071a1 1 0 10-1.414-1.414l-.706.707a1 1 0 101.414 1.414l.707-.707zM3 11a1 1 0 100-2H2a1 1 0 100 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path></svg>
+                    <span class="sr-only">Toggle dark mode</span>
+                </button>
+            </div>
             <p class="text-lg text-muted-foreground">
                 Enter names depending on the input source, then click 'Convert'. Once converted, you can choose to copy individual names or all names to your clipboard.
                 <br><br>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,48 @@
-// Function Definitions
+// Dark Mode Toggle Logic
+const themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
+const themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
+const themeToggleButton = document.getElementById('darkModeToggle');
 
+// Function to update button icon based on theme
+function updateThemeButtonIcon() {
+    if (!themeToggleDarkIcon || !themeToggleLightIcon) return; // Guard against missing elements
+
+    if (document.documentElement.classList.contains('dark') || localStorage.theme === 'dark') {
+        themeToggleLightIcon.classList.remove('hidden');
+        themeToggleDarkIcon.classList.add('hidden');
+    } else {
+        themeToggleDarkIcon.classList.remove('hidden');
+        themeToggleLightIcon.classList.add('hidden');
+    }
+}
+
+// Apply initial theme (on page load)
+if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.classList.add('dark');
+} else {
+    document.documentElement.classList.remove('dark');
+}
+updateThemeButtonIcon(); // Set initial icon state
+
+// Event listener for the toggle button
+if (themeToggleButton) {
+    themeToggleButton.addEventListener('click', function() {
+        // Toggle theme class on <html>
+        document.documentElement.classList.toggle('dark');
+
+        // Update localStorage
+        if (document.documentElement.classList.contains('dark')) {
+            localStorage.theme = 'dark';
+        } else {
+            localStorage.theme = 'light';
+        }
+
+        // Update button icon
+        updateThemeButtonIcon();
+    });
+}
+
+// Original Function Definitions
 // Your copyToClipboard function should be using the Clipboard API:
 function copyToClipboard(text) {
     navigator.clipboard.writeText(text).then(() => {


### PR DESCRIPTION
This commit introduces two enhancements:
1.  An emoji (📝) has been added to the main page header for better visual appeal.
2.  A dark mode toggle has been implemented:
    - A button with sun/moon icons allows you to switch themes.
    - The theme preference is persisted in localStorage.
    - On first visit, the theme respects your system preference (prefers-color-scheme).
All UI components are styled to adapt to both light and dark modes using Tailwind CSS's dark mode variant.

The changes provide you with more visual customization and improve the overall user experience.