### PR TITLE
feat: Update copyAllSorted function to include counts in category headers

### DIFF
--- a/script.js
+++ b/script.js
@@ -532,27 +532,27 @@ function copyAllSorted() {
     let output = "";
     
     if (zugesagt.length > 0) {
-        output += "---- Zugesagt ----\n";
+        output += `---- Zugesagt (${zugesagt.length}) ----\n`;
         output += zugesagt.join('\n') + '\n\n';
     }
     
     if (mitVorbehalt.length > 0) {
-        output += "---- Mit Vorbehalt ----\n";
+        output += `---- Mit Vorbehalt (${mitVorbehalt.length}) ----\n`;
         output += mitVorbehalt.join('\n') + '\n\n';
     }
     
     if (abgelehnt.length > 0) {
-        output += "---- Abgelehnt ----\n";
+        output += `---- Abgelehnt (${abgelehnt.length}) ----\n`;
         output += abgelehnt.join('\n') + '\n\n';
     }
     
     if (keine.length > 0) {
-        output += "---- Keine ----\n";
+        output += `---- Keine (${keine.length}) ----\n`;
         output += keine.join('\n') + '\n\n';
     }
     
     if (unbekannt.length > 0) {
-        output += "---- Unbekannt ----\n";
+        output += `---- Unbekannt (${unbekannt.length}) ----\n`;
         output += unbekannt.join('\n') + '\n\n';
     }
 

--- a/script.test.js
+++ b/script.test.js
@@ -347,11 +347,11 @@ describe('copyAllSorted', () => {
     
     const copiedText = mockWriteText.mock.calls[0][0];
     
-    // Check the structure and content
-    expect(copiedText).toContain('---- Zugesagt ----');
-    expect(copiedText).toContain('---- Mit Vorbehalt ----');
-    expect(copiedText).toContain('---- Abgelehnt ----');
-    expect(copiedText).toContain('---- Keine ----');
+    // Check the structure and content with counts
+    expect(copiedText).toContain('---- Zugesagt (2) ----');
+    expect(copiedText).toContain('---- Mit Vorbehalt (1) ----');
+    expect(copiedText).toContain('---- Abgelehnt (1) ----');
+    expect(copiedText).toContain('---- Keine (1) ----');
     
     // Check that names are properly formatted (flipped from "Last, First" to "First Last")
     expect(copiedText).toContain('Alice Alpha'); // Should be sorted first in Zugesagt

--- a/tests.md
+++ b/tests.md
@@ -103,20 +103,22 @@ These tests verify the TSV (Tab-Separated Values) filtering functionality for de
 
 ## 4. `copyAllSorted` Function Tests
 
-These tests verify the functionality that groups and sorts all TSV entries by status category.
+These tests verify the functionality that groups and sorts all TSV entries by status category, with counts displayed in each category header.
 
 ### Sorting and Grouping Tests
 
-- **Multi-status sorting**: Tests proper categorization of entries into status groups:
-  - Zugesagt (Confirmed)
-  - Mit Vorbehalt (With reservation) 
-  - Abgelehnt (Declined)
-  - Keine (No response)
+- **Multi-status sorting**: Tests proper categorization of entries into status groups with counts:
+  - Zugesagt (2) (Confirmed)
+  - Mit Vorbehalt (1) (With reservation) 
+  - Abgelehnt (1) (Declined)
+  - Keine (1) (No response)
   - Unbekannt (Unknown)
 
 - **Alphabetical sorting**: Verifies that names within each category are sorted alphabetically
 
 - **Name formatting**: Ensures "Lastname, Firstname" entries are properly flipped to "Firstname Lastname"
+
+- **Count display**: Verifies that each category header shows the correct count of people in that category (e.g., "---- Zugesagt (2) ----")
 
 ### Edge Case Handling
 


### PR DESCRIPTION
- Modified the copyAllSorted function to display the count of entries in each status category within the output.
- Updated corresponding tests to verify the new format, ensuring that the counts are correctly reflected in the output.
- Enhanced documentation to reflect changes in the test descriptions for clarity.